### PR TITLE
feat: add on missing data to fix retriggered at 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.0]() (2025-08-11)
+
+### Feature
+
+* Add the variable `var.restart_on_missing_data` to manage the state when there is no change. When the restart value increases to 1 and then returns to 0, the alert does not recover because the recovery threshold requires a value below 0, while the alert threshold is >= 1. Therefore, when the value is 0, the monitor does not recover. The on missing data will fix it whenever the data is at 0.
+
 ## [1.0.1]() (2025-08-11)
 
 ### Feature

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ No resources.
 | <a name="input_p95_metric"></a> [p95\_metric](#input\_p95\_metric) | The metric name used for P95 request latency calculations. | `string` | `"trace.http.request"` | no |
 | <a name="input_pod_monitor_enabled"></a> [pod\_monitor\_enabled](#input\_pod\_monitor\_enabled) | Whether pod monitors (e.g., pod restarts.) should be created. Set to 'true' to create the monitors, 'false' to disable. | `bool` | `false` | no |
 | <a name="input_request_hit_metric"></a> [request\_hit\_metric](#input\_request\_hit\_metric) | The metric name used for counting total requests (hits). | `string` | `"trace.http.request.hits"` | no |
-| <a name="input_restart_on_missing_data"></a> [restart\_on\_missing\_data](#input\_restart\_on\_missing\_data) | The value to use for on\_missing\_data when creating the restart monitor. | `string` | `"default"` | no |
+| <a name="input_restart_on_missing_data"></a> [restart\_on\_missing\_data](#input\_restart\_on\_missing\_data) | The value to use for on\_missing\_data when creating the restart monitor. | `string` | `"resolve"` | no |
 | <a name="input_service_monitor_enabled"></a> [service\_monitor\_enabled](#input\_service\_monitor\_enabled) | Whether service monitors (e.g., p95 latency, request and error hit.) should be created. Set to 'true' to create the monitors, 'false' to disable. | `bool` | `false` | no |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Specify the service name for monitoring. Navigate to Datadog dashboard to have accurate determination. | `string` | n/a | yes |
 | <a name="input_tag_slack_channel"></a> [tag\_slack\_channel](#input\_tag\_slack\_channel) | Whether to tag the Slack channel in the message | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ No resources.
 | <a name="input_p95_metric"></a> [p95\_metric](#input\_p95\_metric) | The metric name used for P95 request latency calculations. | `string` | `"trace.http.request"` | no |
 | <a name="input_pod_monitor_enabled"></a> [pod\_monitor\_enabled](#input\_pod\_monitor\_enabled) | Whether pod monitors (e.g., pod restarts.) should be created. Set to 'true' to create the monitors, 'false' to disable. | `bool` | `false` | no |
 | <a name="input_request_hit_metric"></a> [request\_hit\_metric](#input\_request\_hit\_metric) | The metric name used for counting total requests (hits). | `string` | `"trace.http.request.hits"` | no |
+| <a name="input_restart_on_missing_data"></a> [restart\_on\_missing\_data](#input\_restart\_on\_missing\_data) | The value to use for on\_missing\_data when creating the restart monitor. | `string` | `"default"` | no |
 | <a name="input_service_monitor_enabled"></a> [service\_monitor\_enabled](#input\_service\_monitor\_enabled) | Whether service monitors (e.g., p95 latency, request and error hit.) should be created. Set to 'true' to create the monitors, 'false' to disable. | `bool` | `false` | no |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Specify the service name for monitoring. Navigate to Datadog dashboard to have accurate determination. | `string` | n/a | yes |
 | <a name="input_tag_slack_channel"></a> [tag\_slack\_channel](#input\_tag\_slack\_channel) | Whether to tag the Slack channel in the message | `bool` | `true` | no |

--- a/locals.tf
+++ b/locals.tf
@@ -15,6 +15,8 @@ locals {
       kube_container_name = var.overwrite_container_name != null ? var.overwrite_container_name : var.service_name
     }
 
+    on_missing_data = var.restart_on_missing_data
+
     threshold_critical          = 1
     threshold_critical_recovery = 0.5
     renotify_interval           = 60

--- a/variables.tf
+++ b/variables.tf
@@ -118,3 +118,9 @@ variable "error_hit_metric" {
   type        = string
   default     = "trace.http.request.errors"
 }
+
+variable "restart_on_missing_data" {
+  description = "The value to use for on_missing_data when creating the restart monitor."
+  type        = string
+  default     = "default"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -122,5 +122,5 @@ variable "error_hit_metric" {
 variable "restart_on_missing_data" {
   description = "The value to use for on_missing_data when creating the restart monitor."
   type        = string
-  default     = "default"
+  default     = "resolve"
 }


### PR DESCRIPTION
## Summary
* Add the variable `var.restart_on_missing_data` to manage the state when there is no change. When the restart value increases to 1 and then returns to 0, the alert does not recover because the recovery threshold requires a value below 0, while the alert threshold is >= 1. Therefore, when the value is 0, the monitor does not recover. The on missing data will fix it whenever the data is at 0.

<!--- Add some bells and whistles for PR template. --->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [ ] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
<!--- Please input steps on how to test this PR, including evidence in the form of captured images or videos. If this is not necessary, provide the reason why. --->

## Related Issues
<!--- Add a reference section for management tickets, and relevant conversations. --->
