### PR TITLE
fix: partial override_default_monitors (1.1.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+.idea
+
 **/.terraform
 **/.terraform.lock.hcl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.1]() (2026-06-09)
+
+### Bug Fixes
+
+* Fix `override_default_monitors` so PARTIAL overrides work. Previously the variable's `optional()` attributes (declared without defaults) resolved to `null` when omitted, and the `merge(config, override)` in `service_monitor.tf` / `resource_monitor.tf` let those nulls clobber each default monitor's `title`, `query_template`, and other fields — breaking the generated monitor. Null-valued override attributes are now stripped before merging, so callers can override only the fields they need (for example, just `threshold_critical` and `threshold_critical_recovery` on `p95`) while keeping the rest of the module defaults.
+
 ## [1.1.0]() (2025-08-11)
 
 ### Feature

--- a/README.md
+++ b/README.md
@@ -32,6 +32,33 @@ module "service_monitor" {
 }
 ```
 
+### Override default monitor thresholds
+
+Override only the fields you want to change; everything else (title,
+`query_template`, etc.) keeps the module defaults. Partial overrides are
+supported since `1.1.1`:
+
+```hcl
+module "service_monitor" {
+  source  = "c0x12c/service-monitor/datadog"
+  version = "1.1.1"
+
+  cluster_name                      = "proj-service-dev"
+  service_name                      = "service-platform"
+  environment                       = "dev"
+  notification_slack_channel_prefix = "proj-service-x-"
+
+  service_monitor_enabled = true
+
+  override_default_monitors = {
+    p95 = {
+      threshold_critical          = 2 # alert when P95 latency > 2s
+      threshold_critical_recovery = 1.8
+    }
+  }
+}
+```
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -27,5 +27,12 @@ module "service_monitor" {
       threshold_critical_recovery = 0
       renotify_interval           = 60
     }
+
+    # Partial override (supported since 1.1.1): set only the fields you want to
+    # change; title, query_template, and the rest keep their module defaults.
+    p95 = {
+      threshold_critical          = 2
+      threshold_critical_recovery = 1.8
+    }
   }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,13 @@
 locals {
+  # Strip null-valued attributes from each override so a PARTIAL override (e.g.
+  # only `threshold_critical`) merges cleanly over the default monitor config
+  # instead of clobbering its `title` / `query_template` / etc. with nulls.
+  # Consumed by the merges in service_monitor.tf and resource_monitor.tf.
+  override_default_monitors_clean = {
+    for name, override in var.override_default_monitors :
+    name => { for key, value in override : key => value if value != null }
+  }
+
   # Resource monitor
   default_pod_monitors = merge({
     restart = local.restart

--- a/resource_monitor.tf
+++ b/resource_monitor.tf
@@ -9,7 +9,7 @@ module "pod" {
 
   monitors = {
     for monitor, config in local.default_pod_monitors :
-    monitor => merge(config, try(var.override_default_monitors[monitor], {})) if var.pod_monitor_enabled
+    monitor => merge(config, try(local.override_default_monitors_clean[monitor], {})) if var.pod_monitor_enabled
   }
 }
 
@@ -24,7 +24,7 @@ module "cpu" {
 
   monitors = {
     for monitor, config in local.default_cpu_monitors :
-    monitor => merge(config, try(var.override_default_monitors[monitor], {})) if var.cpu_monitor_enabled
+    monitor => merge(config, try(local.override_default_monitors_clean[monitor], {})) if var.cpu_monitor_enabled
   }
 }
 
@@ -39,6 +39,6 @@ module "memory" {
 
   monitors = {
     for monitor, config in local.default_memory_monitors :
-    monitor => merge(config, try(var.override_default_monitors[monitor], {})) if var.memory_monitor_enabled
+    monitor => merge(config, try(local.override_default_monitors_clean[monitor], {})) if var.memory_monitor_enabled
   }
 }

--- a/service_monitor.tf
+++ b/service_monitor.tf
@@ -9,6 +9,6 @@ module "service" {
 
   monitors = {
     for monitor, config in local.default_service_monitors :
-    monitor => merge(config, try(var.override_default_monitors[monitor], {})) if var.service_monitor_enabled
+    monitor => merge(config, try(local.override_default_monitors_clean[monitor], {})) if var.service_monitor_enabled
   }
 }


### PR DESCRIPTION
## Summary

### Why
`override_default_monitors` only worked as a *full* override. Every attribute is declared `optional()` with no default, so any omitted attribute resolves to `null`. The `merge(config, override)` in `service_monitor.tf` / `resource_monitor.tf` then let those `null`s overwrite each default monitor's `title`, `query_template`, `priority_level`, etc. — producing a broken monitor. Callers had to re-specify every field just to change one threshold.

### What
- Add `local.override_default_monitors_clean` that strips null-valued attributes from each override
- Use it in all 4 monitor blocks: `service`, `pod`, `cpu`, `memory`
- Partial overrides now work — e.g. set only `p95.threshold_critical` and keep the rest of the module defaults
- Docs: README usage example + `examples/complete` partial `p95` override
- CHANGELOG: `1.1.1`

### Solution
Drop null attributes before merging, so the inner module's `optional()` defaults apply instead of being clobbered.

## Types of Changes
- [x] 🐛 Bug fix

## Test Plan
- ✅ `terraform validate` on `examples/complete` (with a partial `p95` override) passes
- ✅ `terraform console` on module locals: partial `p95` override yields `threshold_critical = 2` / `threshold_critical_recovery = 1.8` with `query_template` and `title` preserved
- ✅ `terraform fmt` clean
